### PR TITLE
fix/refact: fix the query_bulk function to handle empty and single ip

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,13 @@ pub async fn query_ip(ip: &str) -> Result<IPInfo, Error> {
 ///
 /// Returns an error if the network request fails or the response cannot be deserialized.
 pub async fn query_bulk(ips: &[&str]) -> Result<Vec<IPInfo>, Error> {
-    let ip_list = ips.join(",");
+    if ips.is_empty() {
+        return Ok(vec![]);
+    }
+    let mut ip_list = ips.join(",");
+    if ips.len() == 1 {
+        ip_list.push(',');
+    }
     let url = format!("{}{}", BASE_URL, ip_list);
     let response = reqwest::get(&url).await?.json::<Vec<IPInfo>>().await?;
     Ok(response)

--- a/tests/integration-test.rs
+++ b/tests/integration-test.rs
@@ -1,38 +1,50 @@
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tokio;
+use ipapi::{query_ip, query_bulk, query_own_ip};
 
-    #[tokio::test]
-    async fn test_query_ip() {
-        let result = query_ip("8.8.8.8").await;
-        assert!(result.is_ok());
+#[tokio::test]
+async fn test_query_ip() {
+    let result = query_ip("8.8.8.8").await;
+    assert!(result.is_ok());
+    let ip_info = result.unwrap();
+    assert_eq!(ip_info.ip, "8.8.8.8");
+    assert!(ip_info.isp.is_some());
+    assert!(ip_info.location.is_some());
+    assert!(ip_info.risk.is_some());
+}
 
-        let ip_info = result.unwrap();
-        assert_eq!(ip_info.ip, "8.8.8.8");
-        assert!(ip_info.isp.is_some());
-        assert!(ip_info.location.is_some());
-        assert!(ip_info.risk.is_some());
-    }
+#[tokio::test]
+async fn test_query_bulk() {
+    let ips = ["8.8.8.8", "1.1.1.1"];
+    let result = query_bulk(&ips).await;
+    assert!(result.is_ok());
+    let ip_infos = result.unwrap();
+    assert_eq!(ip_infos.len(), 2);
+    assert_eq!(ip_infos[0].ip, "8.8.8.8");
+    assert_eq!(ip_infos[1].ip, "1.1.1.1");
+}
 
-    #[tokio::test]
-    async fn test_query_bulk() {
-        let ips = ["8.8.8.8", "1.1.1.1"];
-        let result = query_bulk(&ips).await;
-        assert!(result.is_ok());
+#[tokio::test]
+async fn test_query_bulk_single_ip() {
+    let ips = ["8.8.8.8"];
+    let result = query_bulk(&ips).await;
+    assert!(result.is_ok());
+    let ip_infos = result.unwrap();
+    assert_eq!(ip_infos.len(), 1);
+    assert_eq!(ip_infos[0].ip, "8.8.8.8");
+}
 
-        let ip_infos = result.unwrap();
-        assert_eq!(ip_infos.len(), 2);
-        assert_eq!(ip_infos[0].ip, "8.8.8.8");
-        assert_eq!(ip_infos[1].ip, "1.1.1.1");
-    }
+#[tokio::test]
+async fn test_query_bulk_no_ip() {
+    let ips = [];
+    let result = query_bulk(&ips).await;
+    assert!(result.is_ok());
+    let ip_infos = result.unwrap();
+    assert!(ip_infos.is_empty());
+}
 
-    #[tokio::test]
-    async fn test_query_own_ip() {
-        let result = query_own_ip().await;
-        assert!(result.is_ok());
-
-        let ip = result.unwrap();
-        assert!(!ip.is_empty());
-    }
+#[tokio::test]
+async fn test_query_own_ip() {
+    let result = query_own_ip().await;
+    assert!(result.is_ok());
+    let ip = result.unwrap();
+    assert!(!ip.is_empty());
 }


### PR DESCRIPTION
This PR fixes the `query_bulk` function, and handles input such as `vec![]` and `vec!["1.1.1.1"]`. Also, refactors the tests.

Closes #1 